### PR TITLE
Add path of .kicad_pcb to kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,3 +1,6 @@
 site: https://github.com/intergalaktik/ULX4M
 color: black
 gerbers: plot/gerbers
+eda:
+  type: kicad
+  pcb: ulx4m.kicad_pcb


### PR DESCRIPTION
This is the solution to the problem you mention in https://github.com/kitspace/kitspace/pull/370#issuecomment-970303057, it tells kitspace which .kicad_pcb file to use. 